### PR TITLE
Query formatResults breaks lazy loading in certain cases

### DIFF
--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -41,6 +41,7 @@ class ArticlesFixture extends TestFixture
     public $records = [
         ['author_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y'],
         ['author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
-        ['author_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y']
+        ['author_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y'],
+        ['author_id' => 5, 'title' => 'My author is gone', 'body' => 'Who wrote me?', 'published' => 'Y'],
     ];
 }

--- a/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
+++ b/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace JeremyHarris\LazyLoad\Test\TestCase\ORM;
 
+use Cake\Event\Event;
+use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use JeremyHarris\LazyLoad\TestApp\Model\Entity\Comment;
@@ -216,6 +218,25 @@ class LazyLoadEntityTraitTest extends TestCase
         $tags = $article->tags;
 
         $this->assertEquals(2, count($tags));
+    }
+
+    /**
+     * tests lazy loading
+     *
+     * @return void
+     */
+    public function testLazyLoadNonExistent()
+    {
+        $this->Articles->Authors->eventManager()
+            ->on('Model.beforeFind', function (Event $event, Query $query) {
+                $query->formatResults(function ($resultSet) {
+                    return $resultSet;
+                });
+            });
+        $article = $this->Articles->get(4);
+        $author = $article->author;
+
+        $this->assertNull($author);
     }
 
     /**


### PR DESCRIPTION
Took me far to long to track this one down. I don't believe the problem is a LazyLoader problem, rather something in CakePHP itself, but LazyLoader allows it to manifest itself.

Basically, if you attempt to lazy load an association that does not have anything to load (For example, where the child row has been deleted) AND a behaviour, or callback exists on the target table that adds a result formatter to the query things break badly. It enters an infinite loop trying to load the association. I've only tested belongsTo associations, but I think hasOne might show similar symptoms.
