### PR TITLE
Update `has()` to behave the same as overridden `EntityTrait::has()`

### DIFF
--- a/src/ORM/LazyLoadEntityTrait.php
+++ b/src/ORM/LazyLoadEntityTrait.php
@@ -56,6 +56,7 @@ trait LazyLoadEntityTrait
 
         if ($has === false) {
             $has = $this->_lazyLoad($property);
+
             return !empty($has);
         }
 
@@ -115,6 +116,7 @@ trait LazyLoadEntityTrait
             list(, $class) = namespaceSplit(get_class($this));
             $source = Inflector::pluralize($class);
         }
+
         return TableRegistry::get($source);
     }
 }

--- a/src/ORM/LazyLoadEntityTrait.php
+++ b/src/ORM/LazyLoadEntityTrait.php
@@ -56,7 +56,7 @@ trait LazyLoadEntityTrait
 
         if ($has === false) {
             $has = $this->_lazyLoad($property);
-            return $has !== null;
+            return !empty($has);
         }
 
         return $has;

--- a/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
+++ b/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
@@ -225,12 +225,13 @@ class LazyLoadEntityTraitTest extends TestCase
      */
     public function testHas()
     {
-        $article = $this->Articles->get(1);
+        $article = $this->Articles->get(3);
 
         $serialized = $article->toArray();
         $this->assertArrayNotHasKey('author', $serialized);
 
         $this->assertTrue($article->has('author'));
+        $this->assertFalse($article->has('tags'));
     }
 
     /**


### PR DESCRIPTION
The `LazyLoadEntityTrait::has()` method behaved differently than the
overwritten `EntityTrait::has()` method. The former always returned
true if the property exists for a hasMany relationship, even if there
were no values. The latter returns true only if there are values.
