### PR TITLE
Upgraded PHPUnit constraint to 5.7 in require dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
     - php: 5.5
       env: PREFER_LOWEST=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,13 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
+    - php: 5.5
+      env: PREFER_LOWEST=1
 
 install:
   - composer self-update
-  - composer install --prefer-dist
+  - sh -c "if [ '$PREFER_LOWEST' != '1' ]; then composer install --prefer-dist --no-interaction; fi"
+  - sh -c "if [ '$PREFER_LOWEST' = '1' ]; then composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi"
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "cakephp", "plugin", "lazy load"
     ],
     "require-dev": {
-        "phpunit/phpunit": "~5.7.0",
+        "phpunit/phpunit": "<6.0",
         "cakephp/cakephp-codesniffer": "dev-master",
         "cakephp/cakephp": ">=3.1.0 <4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "cakephp", "plugin", "lazy load"
     ],
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
+        "phpunit/phpunit": "~5.7.0",
         "cakephp/cakephp-codesniffer": "dev-master",
         "cakephp/cakephp": ">=3.1.0 <4.0"
     },

--- a/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
+++ b/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
@@ -117,11 +117,11 @@ class LazyLoadEntityTraitTest extends TestCase
             'foreignKey' => 'user_id'
         ]);
 
-        $comment = $this->getMock(
-            Comment::class,
-            ['_repository'],
-            [['id' => 1, 'user_id' => 2]]
-        );
+        $comment = $this->getMockBuilder(Comment::class)
+            ->setConstructorArgs([['id' => 1, 'user_id' => 2]])
+            ->setMethods(['_repository'])
+            ->getMock();
+
         $comment
             ->expects($this->once())
             ->method('_repository')
@@ -167,11 +167,11 @@ class LazyLoadEntityTraitTest extends TestCase
             'foreignKey' => 'user_id'
         ]);
 
-        $comment = $this->getMock(
-            Comment::class,
-            ['_repository'],
-            [['id' => 1, 'user_id' => 2]]
-        );
+        $comment = $this->getMockBuilder(Comment::class)
+            ->setConstructorArgs([['id' => 1, 'user_id' => 2]])
+            ->setMethods(['_repository'])
+            ->getMock();
+
         $comment
             ->expects($this->once())
             ->method('_repository')
@@ -195,11 +195,11 @@ class LazyLoadEntityTraitTest extends TestCase
             'foreignKey' => 'user_id'
         ]);
 
-        $comment = $this->getMock(
-            Comment::class,
-            ['_repository'],
-            [['id' => 1, 'user_id' => 2]]
-        );
+        $comment = $this->getMockBuilder(Comment::class)
+            ->setConstructorArgs([['id' => 1, 'user_id' => 2]])
+            ->setMethods(['_repository'])
+            ->getMock();
+
         $comment
             ->expects($this->once())
             ->method('_repository')


### PR DESCRIPTION
Tests were breaking in php > 5.6 due to cakephp 3.4 requiring phpunit > 5.7.

Used debug kit as an example of managing php 5.5 because I'm not very good at this.