### PR TITLE
Update deprecated Entity::unsetProperty() to use 4.x Entity::unset()

### DIFF
--- a/src/ORM/LazyLoadEntityTrait.php
+++ b/src/ORM/LazyLoadEntityTrait.php
@@ -91,14 +91,14 @@ trait LazyLoadEntityTrait
      * @param array|string $property Property
      * @return $this
      */
-    public function unsetProperty($property)
+    public function unset($property)
     {
         $property = (array)$property;
         foreach ($property as $prop) {
             $this->_unsetProperties[] = $prop;
         }
 
-        return Entity::unsetProperty($property);
+        return Entity::unset($property);
     }
 
     /**

--- a/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
+++ b/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
@@ -143,6 +143,38 @@ class LazyLoadEntityTraitTest extends TestCase
     }
 
     /**
+     * tests that unsetting a property through proxy of
+     * \Cake\Datasource\EntityTrait::unsetProperty() until its removal
+     *
+     * @return void
+     */
+    public function testUnsetProperty()
+    {
+        $this->Comments = $this->getTableLocator()->get('Comments');
+        $this->Comments->belongsTo('Authors', [
+            'foreignKey' => 'user_id'
+        ]);
+
+        $comment = $this->getMockBuilder(Comment::class)
+            ->setConstructorArgs([['id' => 1, 'user_id' => 2]])
+            ->setMethods(['_repository'])
+            ->getMock();
+
+        $comment
+            ->expects($this->once())
+            ->method('_repository')
+            ->will($this->returnValue($this->Comments));
+
+        $this->assertInstanceOf(EntityInterface::class, $comment->author);
+        $comment->unsetProperty('author');
+        $this->assertNull($comment->author);
+
+        // test re-setting a previously un-set prop
+        $comment->author = 'manual set';
+        $this->assertSame('manual set', $comment->author);
+    }
+
+    /**
      * tests that lazy loading a previously unset eager loaded property does not
      * reload the property
      *

--- a/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
+++ b/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
@@ -175,6 +175,38 @@ class LazyLoadEntityTraitTest extends TestCase
     }
 
     /**
+     * tests that unsetting a property by calling unset($obj->prop) which invokes
+     * \Cake\Datasource\EntityTrait::__unset()
+     *
+     * @return void
+     */
+    public function testUnsetMagicMethod()
+    {
+        $this->Comments = $this->getTableLocator()->get('Comments');
+        $this->Comments->belongsTo('Authors', [
+            'foreignKey' => 'user_id'
+        ]);
+
+        $comment = $this->getMockBuilder(Comment::class)
+            ->setConstructorArgs([['id' => 1, 'user_id' => 2]])
+            ->setMethods(['_repository'])
+            ->getMock();
+
+        $comment
+            ->expects($this->once())
+            ->method('_repository')
+            ->will($this->returnValue($this->Comments));
+
+        $this->assertInstanceOf(EntityInterface::class, $comment->author);
+        unset($comment->author); // invoke magic __unset()
+        $this->assertNull($comment->author);
+
+        // test re-setting a previously un-set prop
+        $comment->author = 'manual set';
+        $this->assertSame('manual set', $comment->author);
+    }
+
+    /**
      * tests that lazy loading a previously unset eager loaded property does not
      * reload the property
      *

--- a/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
+++ b/tests/TestCase/ORM/LazyLoadEntityTraitTest.php
@@ -116,7 +116,7 @@ class LazyLoadEntityTraitTest extends TestCase
      *
      * @return void
      */
-    public function testUnsetProperty()
+    public function testUnset()
     {
         $this->Comments = $this->getTableLocator()->get('Comments');
         $this->Comments->belongsTo('Authors', [
@@ -134,7 +134,7 @@ class LazyLoadEntityTraitTest extends TestCase
             ->will($this->returnValue($this->Comments));
 
         $this->assertInstanceOf(EntityInterface::class, $comment->author);
-        $comment->unsetProperty('author');
+        $comment->unset('author');
         $this->assertNull($comment->author);
 
         // test re-setting a previously un-set prop


### PR DESCRIPTION
Hey hey! It's me again! :D

Hehe, I just noticed that the `unsetProperty()` method was removed when going through some unit tests on a repo I am working with, and properties were coming back from the dead on me!

Found it here in the migration doc.
https://book.cakephp.org/4/en/appendices/4-0-migration-guide.html#orm